### PR TITLE
Adding a matlab gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Windows default autosave extension
+*.asv
+
+# OSX / *nix default autosave extension
+*.m~
+
+# Compiled MEX binaries (all platforms)
+*.mex*
+
+# Packaged app and toolbox files
+*.mlappinstall
+*.mltbx
+
+# Generated helpsearch folders
+helpsearch*/
+
+# Simulink code generation folders
+slprj/
+sccprj/
+
+# Matlab code generation folders
+codegen/
+
+# Simulink autosave extension
+*.autosave
+
+# Simulink cache files
+*.slxc
+
+# Octave session info
+octave-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # OSX / *nix default autosave extension
 *.m~
+DS_Store
 
 # Compiled MEX binaries (all platforms)
 *.mex*


### PR DESCRIPTION
Grabbed from github's defaults:
https://github.com/github/gitignore/blob/master/Global/MATLAB.gitignore