### PR TITLE
Integrate flask python with AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ codegen/
 
 # Octave session info
 octave-workspace
+

--- a/api/.ebextensions/matlab-setup.config
+++ b/api/.ebextensions/matlab-setup.config
@@ -1,0 +1,8 @@
+packages: 
+  yum:
+    libXt: [] 
+    mlocate: []
+commands:
+  command1:
+    command: sudo updatedb
+

--- a/api/.ebextensions/network-load-balancer.config
+++ b/api/.ebextensions/network-load-balancer.config
@@ -1,0 +1,17 @@
+option_settings:
+  - namespace: aws:ec2:vpc
+    option_name: VPCId
+    value: vpc-07bb7df9c5d4b9b6d
+    
+  - namespace: aws:ec2:vpc
+    option_name: Subnets
+    value: subnet-0a38c657ffb418db2
+    
+  - namespace: aws:ec2:vpc
+    option_name: ELBSubnets
+    value: subnet-081d9fa62649333cf
+    
+  - namespace: aws:autoscaling:launchconfiguration
+    option_name: SecurityGroups
+    value: sg-0e19c2aabf5439c4d
+

--- a/api/.ebextensions/options.config
+++ b/api/.ebextensions/options.config
@@ -1,0 +1,7 @@
+option_settings:
+  aws:ec2:instances:
+    InstanceTypes: 't3.micro,t2.micro'
+  aws:autoscaling:asg:
+    MinSize: '1'
+    MaxSize: '1'
+

--- a/api/.ebextensions/storage-efs-mountfilesystem.config
+++ b/api/.ebextensions/storage-efs-mountfilesystem.config
@@ -1,0 +1,106 @@
+###################################################################################################
+#### Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file mounts an Amazon EFS file system to a directory named /efs. To mount
+#### the file system to a different path, modify the MOUNT_DIRECTORY value in the "option_settings"
+#### section.
+####
+#### The FILE_SYSTEM_ID setting references a resource named "FileSystem", which is created by the
+#### storage-efs-createfilesystem.config configuration file. To use this file to mount a
+#### file system that you created outside of AWS Elastic Beanstalk, replace the Ref with the
+#### resource ID (e.g., fs-e7605f4e):
+####
+####      FILE_SYSTEM_ID: fs-e7605f4e
+####
+#### If your environment and file system are in a custom VPC, you must configure the VPC to allow
+#### DNS resolution and DNS host names. See this topic in the VPC User Guide for more information:
+####    http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html
+###################################################################################################
+
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    FILE_SYSTEM_ID: 'fs-ade2004f'
+    MOUNT_DIRECTORY: '/testbed/tools'
+
+##############################################
+#### Do not modify values below this line ####
+##############################################
+    REGION: '`{"Ref": "AWS::Region"}`'
+
+packages:
+  yum:
+    nfs-utils: []
+
+commands:
+  01_mount:
+    command: "/tmp/mount-efs.sh"
+
+files:
+  "/tmp/mount-efs.sh":
+      mode: "000755"
+      content : |
+        #!/bin/bash
+
+        EFS_REGION=$(/opt/elasticbeanstalk/bin/get-config environment -k REGION)
+        EFS_MOUNT_DIR=$(/opt/elasticbeanstalk/bin/get-config environment -k MOUNT_DIRECTORY)
+        EFS_FILE_SYSTEM_ID=$(/opt/elasticbeanstalk/bin/get-config environment -k FILE_SYSTEM_ID)
+
+        echo "Mounting EFS filesystem ${EFS_FILE_SYSTEM_ID} to directory ${EFS_MOUNT_DIR} ..."
+
+        echo 'Stopping NFS ID Mapper...'
+        service rpcidmapd status &> /dev/null
+        if [ $? -ne 0 ] ; then
+            echo 'rpc.idmapd is already stopped!'
+        else
+            service rpcidmapd stop
+            if [ $? -ne 0 ] ; then
+                echo 'ERROR: Failed to stop NFS ID Mapper!'
+                exit 1
+            fi
+        fi
+
+        echo 'Checking if EFS mount directory exists...'
+        if [ ! -d ${EFS_MOUNT_DIR} ]; then
+            echo "Creating directory ${EFS_MOUNT_DIR} ..."
+            mkdir -p ${EFS_MOUNT_DIR}
+            if [ $? -ne 0 ]; then
+                echo 'ERROR: Directory creation failed!'
+                exit 1
+            fi
+        else
+            echo "Directory ${EFS_MOUNT_DIR} already exists!"
+        fi
+
+        mountpoint -q ${EFS_MOUNT_DIR}
+        if [ $? -ne 0 ]; then
+            echo "mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFS_FILE_SYSTEM_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}"
+            mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFS_FILE_SYSTEM_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}
+            if [ $? -ne 0 ] ; then
+                echo 'ERROR: Mount command failed!'
+                exit 1
+            fi
+            chmod 777 ${EFS_MOUNT_DIR}
+            runuser -l  ec2-user -c "touch ${EFS_MOUNT_DIR}/it_works"
+            if [[ $? -ne 0 ]]; then
+                echo 'ERROR: Permission Error!'
+                exit 1
+            else
+                runuser -l  ec2-user -c "rm -f ${EFS_MOUNT_DIR}/it_works"
+            fi
+        else
+            echo "Directory ${EFS_MOUNT_DIR} is already a valid mountpoint!"
+        fi
+
+        echo 'EFS mount complete.'
+

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,9 @@
+# Elastic Beanstalk
+venv_flask
+.ebignore
+
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/api/application.py
+++ b/api/application.py
@@ -3,8 +3,8 @@ from flask_cors import CORS
 
 import subprocess
 
-app = Flask(__name__)
-CORS(app)
+application = Flask(__name__)
+CORS(application)
 
 
 def process_input_payload(data):
@@ -30,7 +30,7 @@ def process_sesam_output(data):
     return payload
 
 
-@app.route('/api/singlepoint', methods=['POST'])
+@application.route('/api/singlepoint', methods=['POST'])
 def sesam_run():
     if not request.json:
         abort(400)
@@ -51,4 +51,4 @@ def sesam_run():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    application.run(debug=True)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,8 @@
+Click==7.0
+Flask==1.0.2
+Flask-Cors==3.0.8
+itsdangerous==1.1.0
+Jinja2==2.11.1
+MarkupSafe==1.1.1
+six==1.14.0
+Werkzeug==0.16.1


### PR DESCRIPTION
This fork integrates the AWS Elastic Beanstalk setup into the VECTOR/api directory. These changes are running successfully on the SWxTREC account at AWS. It required some renaming of the original python flask application.

Next step will be changing the internals of the python flask to call matlab code on the EB server.