### PR TITLE
Integrate VECTOR flask service with matlab

### DIFF
--- a/api/matlab_io.m
+++ b/api/matlab_io.m
@@ -1,0 +1,16 @@
+% test data passing for use in web service
+vector_data_in = getenv('VECTOR_DATA_IN');
+vector_data_out = getenv('VECTOR_DATA_OUT');
+
+% get input data from json file
+data_in = jsondecode(fileread(vector_data_in));
+disp(data_in)
+
+% calculation using data_in array goes here
+data_out = data_in;
+
+% write output data as json
+file_id = fopen(vector_data_out,'wt');
+fprintf(file_id, jsonencode(data_out));
+fclose(file_id);
+

--- a/api/vector_calc.sh
+++ b/api/vector_calc.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# vector_calc.sh data_in_file data_out_file
+
+export VECTOR_DATA_IN=$1
+export VECTOR_DATA_OUT=$2
+
+# /testbed/tools/MATLAB/R2019a/bin/matlab -nodisplay -nosplash -nodesktop -nojvm -batch "run('/home/ec2-user/code_kim/VECTOR/api/matlab_io.m');exit;"
+/testbed/tools/MATLAB/R2019a/bin/matlab -nodisplay -nosplash -nodesktop -nojvm -batch "run('/opt/python/current/app/matlab_io.m');exit;"
+


### PR DESCRIPTION
Integrates the flask service with matlab.

Just a demo for now. The json request to the web service is passed to matlab, decoded to a matlab array, then re-encoded to json, returned to the web service, and finally returned as a json response. There's a comment indicating where a calculation could occur, so it could return something more useful.

Example test:
```
curl -d '{"key1":"1.01", "key2":"2.02"}' -H "Content-Type: application/json" -X POST http://vector-api.us-east-1.elasticbeanstalk.com/api/matlab
{"key1":"1.01","key2":"2.02"}
```
The code can be cleaned up. For now I hacked it together separate from the "singlepoint" route. We can improve it while integrating with the real routes.